### PR TITLE
Make placeholder and other degree search params accessible in the degree search display hook

### DIFF
--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -13,6 +13,8 @@ if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 
 			$output = '';
 			if ( has_filter( 'ucf_degree_search_display' ) ) {
+				// Backward compatibility--use old display hook if a filter is
+				// registered
 				$output = ucf_degree_search_display();
 				$output = apply_filters( 'ucf_degree_search_display', $output );
 			}

--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -11,9 +11,20 @@ if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 
 			ob_start();
 
-			$output = ucf_degree_search_display();
-			
-			echo apply_filters( 'ucf_degree_search_display', $output );
+			$output = '';
+			if ( has_filter( 'ucf_degree_search_display' ) ) {
+				$output = ucf_degree_search_display();
+				$output = apply_filters( 'ucf_degree_search_display', $output );
+			}
+			else {
+				$output = apply_filters( 'ucf_degree_search_input', $output, array(
+					'placeholder' => $placeholder,
+					'result_count' => $result_count,
+					'query_params' => $query_params
+				) );
+			}
+
+			echo $output;
 
 			return ob_get_clean();
 		}
@@ -55,9 +66,12 @@ if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 	}
 }
 
-/** Typahead templates */
+/** Typeahead templates */
 
 if ( ! function_exists( 'ucf_degree_search_display' ) ) {
+	/**
+	 * DEPRECATED as of v0.3.0--use ucf_degree_search_input instead
+	 */
 	function ucf_degree_search_display( $output='' ) {
 		ob_start();
 	?>
@@ -65,6 +79,18 @@ if ( ! function_exists( 'ucf_degree_search_display' ) ) {
 	<?php
 		return ob_get_clean();
 	}
+}
+
+if ( ! function_exists( 'ucf_degree_search_input' ) ) {
+	function ucf_degree_search_input( $output='', $args ) {
+		ob_start();
+	?>
+		<input type="text" class="degree-search-typeahead" placeholder="<?php echo $args['placeholder']; ?>">
+	<?php
+		return ob_get_clean();
+	}
+
+	add_filter( 'ucf_degree_search_input', 'ucf_degree_search_input', 10, 2 );
 }
 
 if ( ! function_exists( 'ucf_degree_search_suggestion' ) ) {


### PR DESCRIPTION
Resolves #26.

I ended up needing to deprecate the existing degree search display hook (`ucf_degree_search_display`) in order to pass more arguments in without causing errors on existing layout overrides in other themes (existing hooks only expect one argument, `$output`).  

This change maintains backward compatibility, but we should consider removing the deprecated code at some point.