### PR TITLE
Add 'Utilize Short Names' Option

### DIFF
--- a/admin/ucf-degree-search-config.php
+++ b/admin/ucf-degree-search-config.php
@@ -215,6 +215,21 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 				)
 			);
 
+			register_setting( 'ucf_degree_search', self::$option_prefix . 'use_short_names' );
+
+			add_settings_field(
+				self::$option_prefix . 'use_short_names',
+				'Utilize Short Names',
+				array( 'UCF_Degree_Search_Config', 'display_settings_field' ),
+				'ucf_degree_search',
+				'ucf_degree_search_section_general',
+				array(
+					'label_for'   => self::$option_prefix . 'use_short_names',
+					'description' => 'If checked, the degree search will use short names for subplan results instead of their titles.',
+					'type'        => 'checkbox'
+				)
+			);
+
 			// Rest API Section
 			add_settings_section(
 				'ucf_degree_search_section_rest_api',

--- a/includes/ucf-degree-search-angular-common.php
+++ b/includes/ucf-degree-search-angular-common.php
@@ -162,6 +162,9 @@ if ( ! class_exists( 'UCF_Degree_Search_Angular_Common' ) ) {
 		}
 
 		public static function search_results_template() {
+			$use_short_names = UCF_Degree_Search_Config::get_option_or_default( 'use_short_names' );
+			$subplan_title = $use_short_names ? 'nameShort' : 'title';
+
 			ob_start();
 		?>
 			<div class="degree-search-results">
@@ -176,7 +179,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Angular_Common' ) ) {
 						<ul class="list-unstyled ml-4 ml-md-5">
 							<li class="search-result-subplan" ng-repeat="subplan in result.subplans">
 								<a href="{{ subplan.url }}" class="degree-title-wrap">
-									<span class="degree-title">{{ subplan.title | convertEncoding }}</span>
+									<span class="degree-title">{{ subplan.<?php echo $subplan_title ?> | convertEncoding }}</span>
 								</a>
 							</li>
 						</ul>


### PR DESCRIPTION
Enhancements:
- Created a setting that for determining whether subplans will use the title or short name in degree search results
- If the 'Utilize Short Names' setting is true, the `nameShort` value is used for the subplan's degree-title, otherwise, the `title` value is used