### PR TITLE
Typeahead form action

### DIFF
--- a/admin/ucf-degree-search-config.php
+++ b/admin/ucf-degree-search-config.php
@@ -10,6 +10,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 				'rest_api_path'       => 'https://www.ucf.edu/online/wp-json/wp/v2/degrees/',
 				'query_params'        => '%q',
 				'number_results'      => 5,
+				'form_action'         => 'https://www.ucf.edu/degree-search/',
 				'include_typeahead'   => true,
 				'angular_api'         => 'https://www.ucf.edu/online/wp-json/ucf-degree-search/v1',
 				'include_angular'     => false,
@@ -32,6 +33,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 			add_option( self::$option_prefix . 'rest_api_path', $defaults['rest_api_path'] );
 			add_option( self::$option_prefix . 'query_params', $defaults['query_params'] );
 			add_option( self::$option_prefix . 'number_results', $defaults['number_results'] );
+			add_option( self::$option_prefix . 'form_action', $defaults['form_action'] );
 			add_option( self::$option_prefix . 'include_typeahead', $defaults['include_typeahead'] );
 			add_option( self::$option_prefix . 'include_angular', $defaults['include_angular'] );
 			add_option( self::$option_prefix . 'angular_api', $defaults['angular_api'] );
@@ -52,6 +54,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 			delete_option( self::$option_prefix . 'rest_api_path' );
 			delete_option( self::$option_prefix . 'query_params' );
 			delete_option( self::$option_prefix . 'number_results' );
+			delete_option( self::$option_prefix . 'form_action' );
 			delete_option( self::$option_prefix . 'include_typeahead' );
 			delete_option( self::$option_prefix . 'include_angular' );
 			delete_option( self::$option_prefix . 'angular_api' );
@@ -75,6 +78,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 				'rest_api_path'     => get_option( self::$option_prefix . 'rest_api_path' ),
 				'query_params'      => get_option( self::$option_prefix . 'query_params' ),
 				'number_results'    => get_option( self::$option_prefix . 'number_results' ),
+				'form_action'       => get_option( self::$option_prefix . 'form_action' ),
 				'include_typeahead' => get_option( self::$option_prefix . 'include_typeahead' ),
 				'include_angular'   => get_option( self::$option_prefix . 'include_angular' ),
 				'angular_api'       => get_option( self::$option_prefix . 'angular_api' ),
@@ -236,6 +240,21 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 					'label_for'   => self::$option_prefix . 'use_short_names',
 					'description' => 'If checked, the degree search will use short names for subplan results instead of their titles.',
 					'type'        => 'checkbox'
+				)
+			);
+
+			register_setting( 'ucf_degree_search', self::$option_prefix . 'form_action' );
+
+			add_settings_field(
+				self::$option_prefix . 'form_action',
+				'Typeahead form action',
+				array( 'UCF_Degree_Search_Config', 'display_settings_field' ),
+				'ucf_degree_search',
+				'ucf_degree_search_section_general',
+				array(
+					'label_for'   => self::$option_prefix . 'form_action',
+					'description' => 'URL that should act as the standard degree search form\'s action. A GET request to this URL will be performed when the degree search form is submitted.',
+					'type'        => 'text'
 				)
 			);
 

--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -4,7 +4,7 @@
  **/
 if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 	class UCF_Degree_Search_Common {
-		public static function display_degree_search( $placeholder, $result_count, $query_params ) {
+		public static function display_degree_search( $placeholder, $result_count, $query_params, $form_action ) {
 			// Override script localization here with shortcode-specific
 			// result_count and query_params
 			UCF_Degree_Search_Common::localize_script( $result_count, $query_params );
@@ -22,7 +22,8 @@ if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 				$output = apply_filters( 'ucf_degree_search_input', $output, array(
 					'placeholder' => $placeholder,
 					'result_count' => $result_count,
-					'query_params' => $query_params
+					'query_params' => $query_params,
+					'form_action' => $form_action
 				) );
 			}
 
@@ -87,7 +88,22 @@ if ( ! function_exists( 'ucf_degree_search_input' ) ) {
 	function ucf_degree_search_input( $output='', $args ) {
 		ob_start();
 	?>
-		<input type="text" class="degree-search-typeahead" placeholder="<?php echo $args['placeholder']; ?>">
+		<?php if ( $args['form_action'] ): ?>
+		<form class="ucf-degree-search" action="<?php echo $args['form_action']; ?>" method="GET">
+			<div class="ucf-degree-search-input-group">
+		<?php endif; ?>
+
+				<input type="text" name="search" class="degree-search-typeahead ucf-degree-search-typeahead" aria-label="Search degree programs" placeholder="<?php echo $args['placeholder']; ?>">
+
+		<?php if ( $args['form_action'] ): ?>
+				<span class="ucf-degree-search-btn-group">
+					<button type="submit" class="ucf-degree-search-submit">
+						<span class="ucf-degree-search-submit-text">Search</span>
+					</button>
+				</span>
+			</div>
+		</form>
+		<?php endif; ?>
 	<?php
 		return ob_get_clean();
 	}

--- a/shortcodes/ucf-degree-search-shortcode.php
+++ b/shortcodes/ucf-degree-search-shortcode.php
@@ -6,12 +6,13 @@ if ( ! class_exists( 'UCF_Degree_Search_Shortcode' ) ) {
 	class UCF_Degree_Search_Shortcode {
 		public static function shortcode( $atts ) {
 			$atts = shortcode_atts( array(
-				'placeholder'       => '',
-				'query_params'      => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_query_params' ),
-				'result_count'      => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_number_results' ),
+				'placeholder'  => '',
+				'query_params' => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_query_params' ),
+				'result_count' => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_number_results' ),
+				'form_action'  => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_form_action' )
 			), $atts );
 
-			return UCF_Degree_Search_Common::display_degree_search( $atts['placeholder'], $atts['result_count'], $atts['query_params'] );
+			return UCF_Degree_Search_Common::display_degree_search( $atts['placeholder'], $atts['result_count'], $atts['query_params'], $atts['form_action'] );
 		}
 	}
 


### PR DESCRIPTION
Adds an optional `form_action` option and shortcode param to the main degree search typeahead.  When provided, the standard typeahead input will be wrapped in a form which submits a GET request to the provided `form_action` value when submitted.