### PR TITLE
Added support for arbitrary form query params in basic degree typeahead shortcode

### DIFF
--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -4,7 +4,7 @@
  **/
 if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 	class UCF_Degree_Search_Common {
-		public static function display_degree_search( $placeholder, $result_count, $query_params, $form_action ) {
+		public static function display_degree_search( $placeholder, $result_count, $query_params, $form_action, $form_query ) {
 			// Override script localization here with shortcode-specific
 			// result_count and query_params
 			UCF_Degree_Search_Common::localize_script( $result_count, $query_params );
@@ -23,7 +23,8 @@ if ( ! class_exists( 'UCF_Degree_Search_Common' ) ) {
 					'placeholder' => $placeholder,
 					'result_count' => $result_count,
 					'query_params' => $query_params,
-					'form_action' => $form_action
+					'form_action' => $form_action,
+					'form_query' => $form_query
 				) );
 			}
 
@@ -91,6 +92,16 @@ if ( ! function_exists( 'ucf_degree_search_input' ) ) {
 		<?php if ( $args['form_action'] ): ?>
 		<form class="ucf-degree-search" action="<?php echo $args['form_action']; ?>" method="GET">
 			<div class="ucf-degree-search-input-group">
+
+			<?php
+			if ( $args['form_query'] ):
+				foreach ( $args['form_query'] as $query_name => $query_value ):
+			?>
+				<input type="hidden" name="<?php echo $query_name; ?>" value="<?php echo $query_value; ?>">
+			<?php
+				endforeach;
+			endif;
+			?>
 		<?php endif; ?>
 
 				<input type="text" name="search" class="degree-search-typeahead ucf-degree-search-typeahead" aria-label="Search degree programs" placeholder="<?php echo $args['placeholder']; ?>">

--- a/shortcodes/ucf-degree-search-shortcode.php
+++ b/shortcodes/ucf-degree-search-shortcode.php
@@ -5,14 +5,42 @@
 if ( ! class_exists( 'UCF_Degree_Search_Shortcode' ) ) {
 	class UCF_Degree_Search_Shortcode {
 		public static function shortcode( $atts ) {
-			$atts = shortcode_atts( array(
+			// Below: dumb workaround for php<5.6 support (due to lack of
+			// ARRAY_FILTER_USE_KEY support on array_filter())
+			$atts_flipped = array_flip( $atts );
+			$form_query_names = array_flip( array_filter( $atts_flipped, function( $key ) {
+				return preg_match( '/^form_query_(\d+)_name$/', $key );
+			} ) );
+			$form_query_vals = array_flip( array_filter( $atts_flipped, function( $key ) {
+				return preg_match( '/^form_query_(\d+)_value$/', $key );
+			} ) );
+
+			$atts = shortcode_atts( array_merge( array(
 				'placeholder'  => '',
 				'query_params' => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_query_params' ),
 				'result_count' => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_number_results' ),
-				'form_action'  => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_form_action' )
-			), $atts );
+				'form_action'  => UCF_Degree_Search_Config::get_option_or_default( 'ucf_degree_search_form_action' ),
+			), $form_query_names, $form_query_vals ), $atts );
 
-			return UCF_Degree_Search_Common::display_degree_search( $atts['placeholder'], $atts['result_count'], $atts['query_params'], $atts['form_action'] );
+			// Get a usable set of query params + values
+			$atts['form_query'] = array();
+			if ( $form_query_names ) {
+				foreach ( $form_query_names as $key => $query_name ) {
+					$keynum = null;
+					$keynum_matches = array();
+					preg_match( '/^form_query_(\d+)_name$/', $key, $keynum_matches );
+					if ( isset( $keynum_matches[1] ) ) {
+						$keynum = $keynum_matches[1];
+					}
+					if ( $keynum && isset( $form_query_vals['form_query_' . $keynum . '_value'] ) ) {
+						$query_name = esc_attr( $query_name );
+						$query_value = esc_attr( $form_query_vals['form_query_' . $keynum . '_value'] );
+						$atts['form_query'][$query_name] = $query_value;
+					}
+				}
+			}
+
+			return UCF_Degree_Search_Common::display_degree_search( $atts['placeholder'], $atts['result_count'], $atts['query_params'], $atts['form_action'], $atts['form_query'] );
 		}
 	}
 


### PR DESCRIPTION
Added the ability to specify unique parameters to pass to the basic degree typeahead's form action when submitted.

For instance,

`[ucf-degree-search form_action="/degree-search/" form_query_1_name="program_types" form_query_1_value="undergraduate-program" form_query_2_name="colleges" form_query_2_value="arts-and-humanities"]`

would generate something like:

```
<form class="ucf-degree-search" action="/degree-search/" method="GET">
  <input name="program_types" value="undergraduate-program" type="hidden">
  <input name="colleges" value="arts-and-humanities" type="hidden">
  ...Typeahead input code here...
  <button type="submit">Submit</button>
</form>
```