### PR TITLE
External degree list

### DIFF
--- a/includes/ucf-degree-external-list-common.php
+++ b/includes/ucf-degree-external-list-common.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Provides common functions for display lists of degrees
+ */
+if ( ! class_exists( 'UCF_Degree_External_List_Common' ) ) {
+    class UCF_Degree_External_List_Common {
+        /**
+         * Displays a list of degrees
+         *
+         * @since 0.7.0
+         * @param array $items The list of degrees.
+         * @param string $layout The layout to use to display the degrees.
+         * @param array $args The argument array
+         */
+        public static function display_degrees( $items, $layout='classic', $args=array() ) {
+            // Return default layout in case the passed in layout doesn't exist
+            $retval = self::default_degree_layout( $items, $args );
+
+            if ( has_filter( `ucf_degree_external_list_{$layout}` ) ) {
+                $retval = apply_filters( `ucf_degree_external_list_{$layout}`, $items, $args, $retval );
+            }
+
+            return $retval;
+        }
+
+        public static function default_degree_layout( $items, $args ) {
+            $heading_element = isset( $args['group_heading'] ) ? $args['group_heading'] : 'h3';
+
+            ob_start();
+
+            foreach( $items->types as $group ) :
+        ?>
+                <<?php echo $heading_element; ?>><?php echo $group->alias; ?></<?php echo $heading_element; ?>>
+                <ul>
+            <?php foreach( $group->degrees as $degree ) : ?>
+                    <li><a href="<?php echo $degree->url; ?>"><?php echo $degree->title; ?></a>
+            <?php endforeach; ?>
+                </ul>
+        <?php
+            endforeach;
+
+            return ob_get_clean();
+        }
+    }
+}

--- a/includes/ucf-degree-external-list-common.php
+++ b/includes/ucf-degree-external-list-common.php
@@ -16,8 +16,8 @@ if ( ! class_exists( 'UCF_Degree_External_List_Common' ) ) {
             // Return default layout in case the passed in layout doesn't exist
             $retval = self::default_degree_layout( $items, $args );
 
-            if ( has_filter( `ucf_degree_external_list_{$layout}` ) ) {
-                $retval = apply_filters( `ucf_degree_external_list_{$layout}`, $items, $args, $retval );
+            if ( has_filter( "ucf_degree_external_list_{$layout}" ) ) {
+                $retval = apply_filters( "ucf_degree_external_list_{$layout}", $items, $args, $retval );
             }
 
             return $retval;

--- a/includes/ucf-degree-search-feed.php
+++ b/includes/ucf-degree-search-feed.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Provides feed utilities for retrieving remote degrees
+ */
+if ( ! class_exists( 'UCF_Degree_Search_Feed' ) ) {
+    class UCF_Degree_Search_Feed {
+        /**
+         * Returns a list of degrees from an external endpoint
+         *
+         * @since 0.7.0
+         * @param array $args The argument array
+         * @param string $search_url The API endpoint's url
+         * @return array The list of degrees
+         */
+        public static function get_degrees( $args, $search_url=null ) {
+            if ( ! $search_url ) {
+                $search_url = UCF_Degree_Search_Config::get_option_or_default( 'angular_api' ) . '/degrees/';
+            }
+
+            // Process params, build full url and get transient name
+            $params = self::process_arguments( $args );
+            $request_url = $search_url . '?' . $params;
+            $transient_name = self::get_transient_name( $request_url );
+            $expiration = 3 * HOUR_IN_SECONDS;
+
+            $degrees = get_transient( $transient_name );
+
+            if ( ! $degrees ) {
+                $request_args = array(
+                    'timeout' => 5
+                );
+
+                $response = wp_remote_get( $request_url, $request_args );
+
+				if ( is_array( $response ) ) {
+					$degrees = json_decode( wp_remote_retrieve_body( $response ) );
+				}
+				else {
+					$degrees = false;
+                }
+
+				// Store new transient data
+				set_transient( $transient_name, $degrees, $expiration );
+            }
+
+            return $degrees;
+        }
+
+        /**
+         * Processes the raw argument array and
+         * returns a parameters string
+         *
+         * @since 0.7.0
+         * @param array $args The argument array
+         * @return string The parameter string
+         */
+        public static function process_arguments( $args ) {
+            $params = array(
+                'limit' => $args['limit']
+            );
+
+            if ( isset( $args['program_types'] ) ) {
+                $params['program_types'] = $args['program_types'];
+            }
+
+            if ( isset( $args['colleges'] ) ) {
+                $params['colleges'] = $args['colleges'];
+            }
+
+            if ( isset( $args['s'] ) ) {
+                $params['s'] = $args['s'];
+            }
+
+            return http_build_query( $params );
+        }
+
+        /**
+         * Return an md5 hash of the full feed url.
+         *
+         * @since 0.7.0
+         * @param string $full_url The full url of the feed, including parameters
+         * @return string The md5 hash of the full url.
+         */
+        private static function get_transient_name( $full_url ) {
+            return md5( $full_url );
+        }
+    }
+}

--- a/includes/ucf-degree-search-feed.php
+++ b/includes/ucf-degree-search-feed.php
@@ -32,15 +32,15 @@ if ( ! class_exists( 'UCF_Degree_Search_Feed' ) ) {
 
                 $response = wp_remote_get( $request_url, $request_args );
 
-				if ( is_array( $response ) ) {
-					$degrees = json_decode( wp_remote_retrieve_body( $response ) );
-				}
-				else {
-					$degrees = false;
+                if ( is_array( $response ) ) {
+                    $degrees = json_decode( wp_remote_retrieve_body( $response ) );
+                }
+                else {
+                    $degrees = false;
                 }
 
-				// Store new transient data
-				set_transient( $transient_name, $degrees, $expiration );
+                // Store new transient data
+                set_transient( $transient_name, $degrees, $expiration );
             }
 
             return $degrees;

--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'UCF_External_Degree_List_Shortcode' ) ) {
             $layout = $atts['layout'];
 
             // Adding filter to allow degrees to be custom sorted for custom layouts.
-            $degrees = apply_filters( `ucf_degree_external_list_sort_{$default}`, $degrees, $layout, $atts );
+            $degrees = apply_filters( "ucf_degree_external_list_sort_{$layout}", $degrees, $layout, $atts );
 
             return UCF_Degree_External_List_Common::display_degrees( $degrees, $layout, $atts );
         }

--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Register the ucf-external-degree-list shortcode
+ */
+if ( ! class_exists( 'UCF_External_Degree_List_Shortcode' ) ) {
+    class UCF_External_Degree_List_Shortcode {
+        public static function shortcode( $atts ) {
+            $atts = shortcode_atts(
+                array(
+                    'program_types' => null,
+                    'colleges'      => null,
+                    'limit'         => -1
+                ),
+                $atts
+            );
+
+            $degrees = UCF_Degree_Search_Feed::get_degrees( $atts );
+
+            return '';
+        }
+    }
+
+    if ( ! shortcode_exists( 'ucf-external-degree-list' ) ) {
+        add_shortcode( 'ucf-external-degree-list', array( 'UCF_External_Degree_List_Shortcode', 'shortcode' ) );
+    }
+}

--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -9,14 +9,19 @@ if ( ! class_exists( 'UCF_External_Degree_List_Shortcode' ) ) {
                 array(
                     'program_types' => null,
                     'colleges'      => null,
+                    'layout'        => 'default',
                     'limit'         => -1
                 ),
                 $atts
             );
 
             $degrees = UCF_Degree_Search_Feed::get_degrees( $atts );
+            $layout = $atts['layout'];
 
-            return '';
+            // Adding filter to allow degrees to be custom sorted for custom layouts.
+            $degrees = apply_filters( `ucf_degree_external_list_sort_{$default}`, $degrees, $layout, $atts );
+
+            return UCF_Degree_External_List_Common::display_degrees( $degrees, $layout, $atts );
         }
     }
 

--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'UCF_External_Degree_List_Shortcode' ) ) {
                 array(
                     'program_types' => null,
                     'colleges'      => null,
-                    'layout'        => 'default',
+                    'layout'        => 'classic',
                     'limit'         => -1
                 ),
                 $atts

--- a/ucf-degree-search.php
+++ b/ucf-degree-search.php
@@ -23,8 +23,10 @@ define( 'UCF_DEGREE_SEARCH__ANGULAR_ROUTE', 'https://cdnjs.cloudflare.com/ajax/l
 
 include_once 'includes/ucf-degree-search-common.php';
 include_once 'includes/ucf-degree-search-angular-common.php';
+include_once 'includes/ucf-degree-search-feed.php';
 include_once 'shortcodes/ucf-degree-search-angular-shortcodes.php';
 include_once 'shortcodes/ucf-degree-search-shortcode.php';
+include_once 'shortcodes/ucf-degree-external-list-shortcode.php';
 include_once 'admin/ucf-degree-search-config.php';
 
 if ( ! function_exists( 'ucf_degree_search_plugin_activation' ) ) {

--- a/ucf-degree-search.php
+++ b/ucf-degree-search.php
@@ -24,6 +24,7 @@ define( 'UCF_DEGREE_SEARCH__ANGULAR_ROUTE', 'https://cdnjs.cloudflare.com/ajax/l
 include_once 'includes/ucf-degree-search-common.php';
 include_once 'includes/ucf-degree-search-angular-common.php';
 include_once 'includes/ucf-degree-search-feed.php';
+include_once 'includes/ucf-degree-external-list-common.php';
 include_once 'shortcodes/ucf-degree-search-angular-shortcodes.php';
 include_once 'shortcodes/ucf-degree-search-shortcode.php';
 include_once 'shortcodes/ucf-degree-external-list-shortcode.php';


### PR DESCRIPTION
Enhancements:
* Adds the ability to list degrees from an external feed source. *Currently, the default layout expects the schema used in `ucf-degree-search/v1/degrees/` endpoint.* However, with a combination of the sort and layout filters, it would be possible to consume and display any degree schema.