### PR TITLE
External degree list warning/notice fixes

### DIFF
--- a/admin/ucf-degree-search-config.php
+++ b/admin/ucf-degree-search-config.php
@@ -319,7 +319,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Config' ) ) {
 				'ucf_degree_search_section_angular',
 				array(
 					'label_for'   => self::$option_prefix . 'angular_api',
-					'description' => 'The REST API url to use for the angular degree search',
+					'description' => 'The REST API url to use for the angular degree search.  Is also used to fetch external degree results via the <code>[ucf-external-degree-list]</code> shortcode.',
 					'type'        => 'text'
 				)
 			);

--- a/includes/ucf-degree-external-list-common.php
+++ b/includes/ucf-degree-external-list-common.php
@@ -28,16 +28,20 @@ if ( ! class_exists( 'UCF_Degree_External_List_Common' ) ) {
 
             ob_start();
 
-            foreach( $items->types as $group ) :
-        ?>
-                <<?php echo $heading_element; ?>><?php echo $group->alias; ?></<?php echo $heading_element; ?>>
-                <ul>
-            <?php foreach( $group->degrees as $degree ) : ?>
-                    <li><a href="<?php echo $degree->url; ?>"><?php echo $degree->title; ?></a>
-            <?php endforeach; ?>
-                </ul>
-        <?php
-            endforeach;
+			if ( $items && isset( $items[0]->types ) ):
+				foreach( $items->types as $group ) :
+			?>
+					<<?php echo $heading_element; ?>><?php echo $group->alias; ?></<?php echo $heading_element; ?>>
+					<ul>
+				<?php foreach( $group->degrees as $degree ) : ?>
+						<li><a href="<?php echo $degree->url; ?>"><?php echo $degree->title; ?></a>
+				<?php endforeach; ?>
+					</ul>
+			<?php
+				endforeach;
+			else:
+				echo '<p>No results found.</p>';
+			endif;
 
             return ob_get_clean();
         }

--- a/includes/ucf-degree-search-feed.php
+++ b/includes/ucf-degree-search-feed.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Feed' ) ) {
                 }
 
                 if ( isset( $sort_by ) && has_filter( "ucf_degree_external_list_sort_{$sort_by}" ) ) {
-                    $degrees = apply_filters( "ucf_degree_external_list_sort_{$sort_by}", $degrees, $layout, $args );
+                    $degrees = apply_filters( "ucf_degree_external_list_sort_{$sort_by}", $degrees, $args );
                 }
 
                 // Store new transient data


### PR DESCRIPTION
- Adds check to ensure `$items` isn't empty and contains what look like valid inner contents in `UCF_Degree_External_List_Common::default_degree_layout()`
- Removed undefined variable `$layout` in the `ucf_degree_external_list_sort_{$sort_by}` hook args

Resolves #66.