### PR TITLE
Added plugin version number to enqueued (non-CDN) scripts

### DIFF
--- a/includes/ucf-degree-search-angular-common.php
+++ b/includes/ucf-degree-search-angular-common.php
@@ -133,7 +133,9 @@ if ( ! class_exists( 'UCF_Degree_Search_Angular_Common' ) ) {
 		}
 
 		public static function enqueue_scripts() {
-			$include_js = UCF_Degree_Search_Config::get_option_or_default( 'include_angular' );
+			$plugin_data = get_plugin_data( UCF_DEGREE_SEARCH__PLUGIN_FILE, false, false );
+			$version     = $plugin_data['Version'];
+			$include_js  = UCF_Degree_Search_Config::get_option_or_default( 'include_angular' );
 
 			$script_deps = array();
 
@@ -147,7 +149,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Angular_Common' ) ) {
 				'ucf-degree-search-angular-js',
 				UCF_DEGREE_SEARCH__STATIC_URL . '/js/ucf-degree-search-angular.min.js',
 				$script_deps,
-				null,
+				$version,
 				true
 			);
 		}

--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -157,7 +157,9 @@ if ( ! function_exists( 'ucf_degree_search_footer' ) ) {
 
 if ( ! function_exists( 'ucf_degree_search_enqueue_scripts' ) ) {
 	function ucf_degree_search_enqueue_scripts() {
-		$include_js = UCF_Degree_Search_Config::get_option_or_default( 'include_typeahead' );
+		$plugin_data = get_plugin_data( UCF_DEGREE_SEARCH__PLUGIN_FILE, false, false );
+		$version     = $plugin_data['Version'];
+		$include_js  = UCF_Degree_Search_Config::get_option_or_default( 'include_typeahead' );
 
 		$script_deps = array();
 
@@ -171,7 +173,7 @@ if ( ! function_exists( 'ucf_degree_search_enqueue_scripts' ) ) {
 			'ucf-degree-search-js',
 			UCF_DEGREE_SEARCH__STATIC_URL . '/js/ucf-degree-search.min.js',
 			$script_deps,
-			null,
+			$version,
 			true
 		);
 
@@ -181,7 +183,7 @@ if ( ! function_exists( 'ucf_degree_search_enqueue_scripts' ) ) {
 			'ucf-degree-search-common-js',
 			UCF_DEGREE_SEARCH__STATIC_URL . '/js/ucf-degree-search-common.min.js',
 			null,
-			null,
+			$version,
 			true
 		);
 


### PR DESCRIPTION
Ensure that browser-level cache-busting occurs on enqueued js files when the plugin is updated to a new version.