### PR TITLE
Degree search typeahead late JS enqueue action hook

### DIFF
--- a/includes/ucf-degree-search-common.php
+++ b/includes/ucf-degree-search-common.php
@@ -187,5 +187,6 @@ if ( ! function_exists( 'ucf_degree_search_register_scripts' ) ) {
 if ( ! function_exists( 'ucf_degree_search_enqueue_scripts' ) ) {
 	function ucf_degree_search_enqueue_scripts() {
 		wp_enqueue_script( 'ucf-degree-search-js' );
+		do_action( 'ucf_degree_search_enqueue_scripts_after' );
 	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Degree-Search-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Degree-Search-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a new action hook, `ucf_degree_search_enqueue_scripts_after`, for themes/other plugins to enqueue dependent scripts or perform other actions when degree search js late-enqueues.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So that sites that initialize typeaheads with custom logic can do so and ensure their script enqueues after `ucf-degree-search.min.js`.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly. - will update after this change is approved and tagged
