### PR TITLE
Added an alias to the degree-list shortcode

### DIFF
--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -30,12 +30,12 @@ if (! class_exists('UCF_External_Degree_List_Shortcode')) {
 		}
 	}
 
-	if (! shortcode_exists('ucf-external-degree-list')) {
-		add_shortcode('ucf-external-degree-list', array('UCF_External_Degree_List_Shortcode', 'shortcode'));
+	if ( ! shortcode_exists( 'ucf-external-degree-list' ) ) {
+		add_shortcode( 'ucf-external-degree-list', array( 'UCF_External_Degree_List_Shortcode', 'shortcode' ) );
 	}
 
 	/**
-	 * Create an alias for the ucf-external-degree-list shortcode to degree-list
+	 * Create an alias for the ucf-external-degree-list shortcode as `degree-list`.
 	 */
 	if ( ! shortcode_exists( 'degree-list' ) ) {
 		add_shortcode( 'degree-list', array( 'UCF_External_Degree_List_Shortcode', 'shortcode' ) );

--- a/shortcodes/ucf-degree-external-list-shortcode.php
+++ b/shortcodes/ucf-degree-external-list-shortcode.php
@@ -33,4 +33,11 @@ if (! class_exists('UCF_External_Degree_List_Shortcode')) {
 	if (! shortcode_exists('ucf-external-degree-list')) {
 		add_shortcode('ucf-external-degree-list', array('UCF_External_Degree_List_Shortcode', 'shortcode'));
 	}
+
+	/**
+	 * Create an alias for the ucf-external-degree-list shortcode to degree-list
+	 */
+	if ( ! shortcode_exists( 'degree-list' ) ) {
+		add_shortcode( 'degree-list', array( 'UCF_External_Degree_List_Shortcode', 'shortcode' ) );
+	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Degree-Search-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Degree-Search-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds `degree-list` as an alias to the `ucf-external-degree-list` shortcode. We will deprecate the `ucf-external-degree-list` when this version is tagged.

**Motivation and Context**
We're working towards transitioning from calling this the "external" degree list to just the degree list. We will also be deprecating the `degree-list` as defined in the UCF-Degree-CPT-Plugin.

**How Has This Been Tested?**
I can confirm that when the degree-cpt plugin is inactive, the alias works as intended. When it is active, the existing degree-list shortcode on the UCF-Degree-CPT-Plugin takes precedence.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
